### PR TITLE
Fix issue 37455

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+# Terraform Submodule Configuration for Providers
+
+## Overview
+
+In Terraform configurations, the `required_providers` block is used to specify the providers needed for a module. This block is crucial for managing provider dependencies, ensuring compatibility, and maintaining clarity in your infrastructure code.
+
+### HashiCorp Providers
+
+**HashiCorp Providers** are Terraform providers developed and maintained by HashiCorp, the creators of Terraform. Examples include providers like `aws`, `azurerm` (Azure), `google` (GCP), and `hashicorp/vault`. These providers are hosted in the official Terraform Registry under the HashiCorp namespace.
+
+For HashiCorp providers, defining the `required_providers` block in submodules is not strictly necessary because Terraform automatically fetches these providers from the official registry if they are referenced in the configuration. However, it is considered a **best practice** to explicitly define the `required_providers` block in submodules. This ensures clarity, enforces version constraints, and improves maintainability by making dependencies explicit.
+
+### Non-HashiCorp Providers
+
+**Non-HashiCorp Providers** are Terraform providers developed by third parties or the community, not maintained by HashiCorp. Examples include providers like `datadog`, `newrelic`, or custom providers hosted outside the official HashiCorp namespace. These providers may be sourced from the Terraform Registry, custom registries, or other locations.
+
+For Non-HashiCorp providers, you **must explicitly define** the `required_providers` block in your submodule. This is because Terraform does not automatically resolve these providers, and the block is needed to specify the source and version of the provider to ensure proper initialization and compatibility.
+
+## Best Practice
+
+To maintain consistency and clarity across your Terraform configurations, always include the `required_providers` block in your submodules, regardless of whether the provider is HashiCorp or Non-HashiCorp. This practice helps document dependencies, enforce version constraints, and avoid unexpected behavior during provider initialization.
+
+### Example `required_providers` Block
+
+```hcl
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    datadog = {
+      source  = "DataDog/datadog"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/env/dev/providers.tf
+++ b/env/dev/providers.tf
@@ -1,0 +1,5 @@
+provider "alicloud" {
+  access_key = var.alicloud_access_key
+  secret_key = var.alicloud_secret_key
+  region     = "cn-beijing"
+}

--- a/env/dev/variables.tf
+++ b/env/dev/variables.tf
@@ -1,10 +1,3 @@
-provider "alicloud" {
-  access_key = var.alicloud_access_key
-  secret_key = var.alicloud_secret_key
-  region     = "cn-beijing"
-}
-
-
 variable "alicloud_access_key" {
   type = string
 }

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -1,9 +1,12 @@
 variable "vpc_cidr_block" {
+    type = string
 }
 
 variable "vpc_name" {
+    type = string
 }
 
 
 variable "vsw_cidr_block" {
+    type = string
 }

--- a/modules/vpc/versions.tf
+++ b/modules/vpc/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    alicloud = {
+      source  = "aliyun/alicloud"
+      version = "1.257.0"
+    }
+  }
+}


### PR DESCRIPTION
Because alibaba cloud is a third-party provider..you are facing this issue

│ Provider "registry.terraform.io/hashicorp/alicloud" requires explicit configuration. Add a provider block
│ to the root module and configure the provider's required arguments as described in the provider
│ documentation.


For Below Error: You should create a terraform.tfvars and assign your provider secret there and add it in .gitignore so the key you will keep within your system

│ Error: configuring Terraform Alibaba Cloud Provider: no valid credential sources for Terraform Alibaba Cloud Provider found.
│
│ Please see https://registry.terraform.io/providers/aliyun/alicloud/latest/docs#authentication
│ for more information about providing credentials.
│
│ with provider["registry.terraform.io/hashicorp/alicloud"],
│ on line 0:
│ (source code not available)